### PR TITLE
Update README - Vertex Task only supports Models with Predict Method

### DIFF
--- a/src/vertex-ai-task/README.md
+++ b/src/vertex-ai-task/README.md
@@ -4,6 +4,8 @@ This sample integration contains a flow to be used as a sub-integration for inte
 
 Each task has a description that explains what the task is used for that you can see in the Integration UI.
 
+This sample uses task "Vertex AI - Predict" which only supports Text Models eg text-bison, text-unicorn. Text models are ideal for tasks that can be completed with one API response, without the need for continuous conversation.
+
 ## Prerequisites
 
 - You must have enabled the [Vertex AI API](https://cloud.google.com/vertex-ai/docs/start/cloud-environment) in your project.

--- a/src/vertex-ai-task/README.md
+++ b/src/vertex-ai-task/README.md
@@ -4,7 +4,9 @@ This sample integration contains a flow to be used as a sub-integration for inte
 
 Each task has a description that explains what the task is used for that you can see in the Integration UI.
 
-This sample uses task "Vertex AI - Predict" which only supports Text Models eg text-bison, text-unicorn. Text models are ideal for tasks that can be completed with one API response, without the need for continuous conversation.
+This sample uses task "Vertex AI - Predict" which only supports Models with Predict method eg text-bison, text-unicorn. e.g. 
+https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/text#sample_request
+https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/code-chat#http_request
 
 ## Prerequisites
 


### PR DESCRIPTION
I was playing with vertex-ai-task sample in Australia region, and realised that it works only with Text Models eg text-bison, text-unicorn. More details [https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/text](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/text)


**Error Scenarios**
1. When I tried with Gemini, it returned "Code 400, Gemini cannot be accessed through Vertex Predict/RawPredict API."
2. When I tried with code-bison, it returned "Code 400, Invalid Argument, Instance Prefix cannot be empty"